### PR TITLE
Add RxSwift 5 sample app

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -12,18 +12,14 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Generate project
-      run: swift package generate-xcodeproj --enable-code-coverage
-    - name: Run tests
-      run: set -o pipefail && xcodebuild -project CombineRx.xcodeproj -scheme CombineRx-Package -enableCodeCoverage YES -sdk macosx -destination "arch=x86_64" test | xcpretty -c -r html --output logs/macOS.html
-    - uses: codecov/codecov-action@v1.0.5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        name: CombineRx
-    - uses: actions/upload-artifact@v1
-      with:
-        name: build-logs-${{ github.run_id }}
-        path: logs
-    - name: Update coverage
-      run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test --enable-code-coverage
+      - name: Determine coverage
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: CombineRx
+          xcode: true

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.pbxproj
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.pbxproj
@@ -1,0 +1,419 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		ECCD2CD6283CDB8100663179 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2CD5283CDB8100663179 /* AppDelegate.swift */; };
+		ECCD2CD8283CDB8100663179 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2CD7283CDB8100663179 /* SceneDelegate.swift */; };
+		ECCD2CDA283CDB8100663179 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2CD9283CDB8100663179 /* ViewController.swift */; };
+		ECCD2CDF283CDB8400663179 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ECCD2CDE283CDB8400663179 /* Assets.xcassets */; };
+		ECCD2CE2283CDB8400663179 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ECCD2CE0283CDB8400663179 /* LaunchScreen.storyboard */; };
+		ECCD2D0F283CDF8800663179 /* MathsExpressionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2D0E283CDF8800663179 /* MathsExpressionClient.swift */; };
+		ECCD2D12283CDFB100663179 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = ECCD2D11283CDFB100663179 /* RxCocoa */; };
+		ECCD2D14283CDFB100663179 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = ECCD2D13283CDFB100663179 /* RxSwift */; };
+		ECCD2D16283CDFDF00663179 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2D15283CDFDF00663179 /* Expression.swift */; };
+		ECCD2D18283CE13000663179 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2D17283CE13000663179 /* ViewModel.swift */; };
+		ECCD2D25283CF4AF00663179 /* CombineRx in Frameworks */ = {isa = PBXBuildFile; productRef = ECCD2D24283CF4AF00663179 /* CombineRx */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		ECCD2CD2283CDB8100663179 /* RxSwift 5 App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "RxSwift 5 App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECCD2CD5283CDB8100663179 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		ECCD2CD7283CDB8100663179 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		ECCD2CD9283CDB8100663179 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		ECCD2CDE283CDB8400663179 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		ECCD2CE1283CDB8400663179 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		ECCD2CE3283CDB8400663179 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ECCD2D0D283CDE6700663179 /* CombineRx */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = CombineRx; path = ../..; sourceTree = "<group>"; };
+		ECCD2D0E283CDF8800663179 /* MathsExpressionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathsExpressionClient.swift; sourceTree = "<group>"; };
+		ECCD2D15283CDFDF00663179 /* Expression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expression.swift; sourceTree = "<group>"; };
+		ECCD2D17283CE13000663179 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		ECCD2CCF283CDB8100663179 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECCD2D14283CDFB100663179 /* RxSwift in Frameworks */,
+				ECCD2D25283CF4AF00663179 /* CombineRx in Frameworks */,
+				ECCD2D12283CDFB100663179 /* RxCocoa in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		ECCD2CC9283CDB8100663179 = {
+			isa = PBXGroup;
+			children = (
+				ECCD2D0C283CDE6700663179 /* Packages */,
+				ECCD2CD4283CDB8100663179 /* RxSwift 5 App */,
+				ECCD2CD3283CDB8100663179 /* Products */,
+				ECCD2D23283CF4AF00663179 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		ECCD2CD3283CDB8100663179 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				ECCD2CD2283CDB8100663179 /* RxSwift 5 App.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		ECCD2CD4283CDB8100663179 /* RxSwift 5 App */ = {
+			isa = PBXGroup;
+			children = (
+				ECCD2CD5283CDB8100663179 /* AppDelegate.swift */,
+				ECCD2CD7283CDB8100663179 /* SceneDelegate.swift */,
+				ECCD2D15283CDFDF00663179 /* Expression.swift */,
+				ECCD2D0E283CDF8800663179 /* MathsExpressionClient.swift */,
+				ECCD2D17283CE13000663179 /* ViewModel.swift */,
+				ECCD2CD9283CDB8100663179 /* ViewController.swift */,
+				ECCD2CDE283CDB8400663179 /* Assets.xcassets */,
+				ECCD2CE0283CDB8400663179 /* LaunchScreen.storyboard */,
+				ECCD2CE3283CDB8400663179 /* Info.plist */,
+			);
+			path = "RxSwift 5 App";
+			sourceTree = "<group>";
+		};
+		ECCD2D0C283CDE6700663179 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				ECCD2D0D283CDE6700663179 /* CombineRx */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		ECCD2D23283CF4AF00663179 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		ECCD2CD1283CDB8100663179 /* RxSwift 5 App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECCD2CE6283CDB8400663179 /* Build configuration list for PBXNativeTarget "RxSwift 5 App" */;
+			buildPhases = (
+				ECCD2CCE283CDB8100663179 /* Sources */,
+				ECCD2CCF283CDB8100663179 /* Frameworks */,
+				ECCD2CD0283CDB8100663179 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RxSwift 5 App";
+			packageProductDependencies = (
+				ECCD2D11283CDFB100663179 /* RxCocoa */,
+				ECCD2D13283CDFB100663179 /* RxSwift */,
+				ECCD2D24283CF4AF00663179 /* CombineRx */,
+			);
+			productName = "RxSwift 5 App";
+			productReference = ECCD2CD2283CDB8100663179 /* RxSwift 5 App.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		ECCD2CCA283CDB8100663179 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1340;
+				LastUpgradeCheck = 1340;
+				TargetAttributes = {
+					ECCD2CD1283CDB8100663179 = {
+						CreatedOnToolsVersion = 13.4;
+					};
+				};
+			};
+			buildConfigurationList = ECCD2CCD283CDB8100663179 /* Build configuration list for PBXProject "RxSwift 5 App" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = ECCD2CC9283CDB8100663179;
+			packageReferences = (
+				ECCD2D10283CDFB100663179 /* XCRemoteSwiftPackageReference "RxSwift" */,
+			);
+			productRefGroup = ECCD2CD3283CDB8100663179 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				ECCD2CD1283CDB8100663179 /* RxSwift 5 App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		ECCD2CD0283CDB8100663179 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECCD2CE2283CDB8400663179 /* LaunchScreen.storyboard in Resources */,
+				ECCD2CDF283CDB8400663179 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		ECCD2CCE283CDB8100663179 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECCD2CDA283CDB8100663179 /* ViewController.swift in Sources */,
+				ECCD2CD6283CDB8100663179 /* AppDelegate.swift in Sources */,
+				ECCD2D0F283CDF8800663179 /* MathsExpressionClient.swift in Sources */,
+				ECCD2CD8283CDB8100663179 /* SceneDelegate.swift in Sources */,
+				ECCD2D18283CE13000663179 /* ViewModel.swift in Sources */,
+				ECCD2D16283CDFDF00663179 /* Expression.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		ECCD2CE0283CDB8400663179 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				ECCD2CE1283CDB8400663179 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		ECCD2CE4283CDB8400663179 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		ECCD2CE5283CDB8400663179 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		ECCD2CE7283CDB8400663179 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "RxSwift 5 App/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jackstone.RxSwift-5-App";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		ECCD2CE8283CDB8400663179 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "RxSwift 5 App/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jackstone.RxSwift-5-App";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		ECCD2CCD283CDB8100663179 /* Build configuration list for PBXProject "RxSwift 5 App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ECCD2CE4283CDB8400663179 /* Debug */,
+				ECCD2CE5283CDB8400663179 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ECCD2CE6283CDB8400663179 /* Build configuration list for PBXNativeTarget "RxSwift 5 App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ECCD2CE7283CDB8400663179 /* Debug */,
+				ECCD2CE8283CDB8400663179 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		ECCD2D10283CDFB100663179 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "git@github.com:ReactiveX/RxSwift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		ECCD2D11283CDFB100663179 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = ECCD2D10283CDFB100663179 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		ECCD2D13283CDFB100663179 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = ECCD2D10283CDFB100663179 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		ECCD2D24283CF4AF00663179 /* CombineRx */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CombineRx;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = ECCD2CCA283CDB8100663179 /* Project object */;
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "combine-schedulers",
+        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
+        "state": {
+          "branch": null,
+          "revision": "4cf088c29a20f52be0f2ca54992b492c54e0076b",
+          "version": "0.5.3"
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "git@github.com:ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "cec68169a048a079f461ba203fe85636548d7a89",
+          "version": "5.1.3"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/AppDelegate.swift
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/AppDelegate.swift
@@ -1,0 +1,31 @@
+//
+//  AppDelegate.swift
+//  RxSwift 5 App
+//
+//  Created by Jack Stone on 24/05/2022.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/Assets.xcassets/Contents.json
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/Base.lproj/LaunchScreen.storyboard
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/Expression.swift
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/Expression.swift
@@ -1,0 +1,16 @@
+//
+//  Expression.swift
+//  RxSwift 5 App
+//
+//  Created by Jack Stone on 24/05/2022.
+//
+
+import Foundation
+
+struct Expression: Equatable, Codable {
+    let first: Int
+    let second: Int
+    let answer: Int
+    let operation: String
+    let expression: String
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/Info.plist
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/MathsExpressionClient.swift
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/MathsExpressionClient.swift
@@ -1,0 +1,42 @@
+//
+//  MathsExpressionClient.swift
+//  RxSwift 5 App
+//
+//  Created by Jack Stone on 24/05/2022.
+//
+
+import Foundation
+import Combine
+
+// MARK: - Interface
+struct MathsExpressionClient {
+
+    enum Error: Swift.Error {
+        case invalidURL
+        case networkError(Swift.Error)
+        case decodingError(Swift.Error)
+    }
+
+    let randomExpression: () -> AnyPublisher<Expression, Error>
+}
+
+// MARK: - Live
+extension MathsExpressionClient {
+
+    static func live(session: URLSession) -> Self {
+        Self(
+            randomExpression: {
+                guard let endpoint = URL(string: "https://x-math.herokuapp.com/api/random") else {
+                    return Fail(error: .invalidURL).eraseToAnyPublisher()
+                }
+
+                return session.dataTaskPublisher(for: endpoint)
+                    .mapError { Error.networkError($0) }
+                    .map(\.data)
+                    .decode(type: Expression.self, decoder: JSONDecoder())
+                    .mapError { Error.decodingError($0) }
+                    .eraseToAnyPublisher()
+            }
+        )
+    }
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/SceneDelegate.swift
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/SceneDelegate.swift
@@ -1,0 +1,64 @@
+//
+//  SceneDelegate.swift
+//  RxSwift 5 App
+//
+//  Created by Jack Stone on 24/05/2022.
+//
+
+import UIKit
+import RxSwift
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        let viewModel = ViewModel(
+            client: .live(session: .shared),
+            mainScheduler: MainScheduler.asyncInstance
+        )
+
+        let viewController = ViewController(viewModel: viewModel)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.navigationBar.prefersLargeTitles = true
+
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}
+

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/ViewController.swift
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/ViewController.swift
@@ -1,0 +1,145 @@
+//
+//  ViewController.swift
+//  RxSwift 5 App
+//
+//  Created by Jack Stone on 24/05/2022.
+//
+
+import UIKit
+import Combine
+import RxSwift
+import RxCocoa
+import CombineRx
+
+class ViewController: UIViewController {
+
+    private let viewModel: ViewModel
+    private let disposeBag = DisposeBag()
+    private var subscriptions = Set<AnyCancellable>()
+
+    private lazy var activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
+
+    private lazy var expressionAndAnswerLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .title1)
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var button: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    init(viewModel: ViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+        setupBindings()
+        setupSubscriptions()
+    }
+
+    private func setupViews() {
+        view.backgroundColor = .white
+
+        setupExpressionAndAnswerLabel()
+        setupButton()
+        setupActivityIndicator()
+    }
+
+    private func setupExpressionAndAnswerLabel() {
+        view.addSubview(expressionAndAnswerLabel)
+
+        NSLayoutConstraint.activate([
+            expressionAndAnswerLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            expressionAndAnswerLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+
+    private func setupButton() {
+        view.addSubview(button)
+
+        NSLayoutConstraint.activate([
+            button.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            button.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+
+    private func setupActivityIndicator() {
+        view.addSubview(activityIndicator)
+
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+
+    private func setupBindings() {
+        Observable.just(viewModel.title)
+            .asPublisher(withBufferSize: 1, andBridgeBufferingStrategy: .error)
+            .catchToEmpty()
+            .sink { [unowned self] title in self.title = title }
+            .store(in: &subscriptions)
+
+        Observable.just(viewModel.buttonLabel)
+            .asPublisher(withBufferSize: 1, andBridgeBufferingStrategy: .error)
+            .catchToEmpty()
+            .sink { [unowned self] title in self.button.setTitle(title, for: .normal) }
+            .store(in: &subscriptions)
+
+        viewModel.expressionAndAnswerObservable
+            .asPublisher(withBufferSize: 1, andBridgeBufferingStrategy: .error)
+            .catchToEmpty()
+            .sink { [unowned self] label in self.expressionAndAnswerLabel.text = label }
+            .store(in: &subscriptions)
+
+        viewModel.isLoadingObservable
+            .asPublisher(withBufferSize: 1, andBridgeBufferingStrategy: .error)
+            .catchToEmpty()
+            .sink { [unowned self] isLoading in
+                switch isLoading {
+                case true:  self.activityIndicator.startAnimating()
+                case false: self.activityIndicator.stopAnimating()
+                }
+            }
+            .store(in: &subscriptions)
+
+        viewModel.isLoadingObservable
+            .asPublisher(withBufferSize: 1, andBridgeBufferingStrategy: .error)
+            .catchToEmpty()
+            .sink { [unowned self] isLoading in self.expressionAndAnswerLabel.isHidden = isLoading }
+            .store(in: &subscriptions)
+    }
+
+    private func setupSubscriptions() {
+        button.rx.tap
+            .asDriver()
+            .drive(viewModel.buttonTapSubject)
+            .disposed(by: disposeBag)
+    }
+}
+
+private extension Publisher {
+
+    func catchToEmpty() -> AnyPublisher<Output, Never> {
+        self
+            .catch { _ in Empty().eraseToAnyPublisher() }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sample Projects/RxSwift 5 App/RxSwift 5 App/ViewModel.swift
+++ b/Sample Projects/RxSwift 5 App/RxSwift 5 App/ViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  ViewModel.swift
+//  RxSwift 5 App
+//
+//  Created by Jack Stone on 24/05/2022.
+//
+
+import Foundation
+import RxSwift
+import CombineRx
+
+final class ViewModel {
+
+    enum State: Equatable {
+        case pending
+        case loading
+        case loaded(Expression)
+        case error
+    }
+
+    var expressionAndAnswerObservable: Observable<String> {
+        stateSubject
+            .skipWhile { $0 == .pending }
+            .map { state in
+                guard let expression = state.expression else { return "" }
+                return [expression.expression, "=", String(expression.answer)].joined(separator: " ")
+            }
+    }
+
+    var isLoadingObservable: Observable<Bool> {
+        stateSubject
+            .skipWhile { $0 == .pending }
+            .map { $0 == .loading }
+    }
+
+    var title: String { "Maths Expressions" }
+    var buttonLabel: String { "Random Expression" }
+
+    let buttonTapSubject = PublishSubject<Void>()
+
+    private let stateSubject = BehaviorSubject<State>(value: .pending)
+
+    private let client: MathsExpressionClient
+    private let mainScheduler: SchedulerType
+    private let disposeBag = DisposeBag()
+
+    init(
+        client: MathsExpressionClient,
+        mainScheduler: SchedulerType
+    ) {
+        self.client = client
+        self.mainScheduler = mainScheduler
+
+        subscribeToButtonTapObservable()
+    }
+
+    private func subscribeToButtonTapObservable() {
+        buttonTapSubject
+            .debounce(.milliseconds(300), scheduler: mainScheduler)
+            .subscribe(onNext: { [unowned self] in self.fetchRandomExpression() })
+            .disposed(by: disposeBag)
+    }
+
+    private func fetchRandomExpression() {
+        guard let value = try? stateSubject.value(), value != .loading else { return }
+
+        stateSubject.onNext(.loading)
+
+        client.randomExpression()
+            .asObservable()
+            .observeOn(mainScheduler)
+            .subscribe(
+                onNext: { [unowned self] expression in self.stateSubject.onNext(.loaded(expression)) },
+                onError: { [unowned self] _ in self.stateSubject.onNext(.error) }
+            )
+            .disposed(by: disposeBag)
+    }
+}
+
+private extension ViewModel.State {
+
+    var expression: Expression? {
+        switch self {
+        case .loaded(let expression):
+            return expression
+
+        case .pending, .loading, .error:
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## What's Changed?

- Added a sample project that uses RxSwift version 5.x.x. This will be used to ensure that any future CombineRx 1.x.x releases will continue to support RxSwift 5.x.x.

## Further Details
In the lead up to supporting RxSwift 6.x.x, we want to ensure that users who rely on RxSwift 5.x.x continue to be able to use CombineRx. Because there doesn't seem to be a way to selectively derive a version of a Swift Package dependency (only `swift`, `os` or `iOS` versions or `arch` type), CombineRx version 2.x.x and up will support RxSwift 6.x.x. 
However, versions 1.x.x up to the next major will continue to support RxSwift 5.x.x in the meantime.

The sample app provided is a simple maths equation fetcher that makes an API request to receive a random mathematical equation. It simulates a small-scale use-case for CombineRx:
- The client is written using Combine
- The `ViewModel` uses RxSwift and therefore must convert the client output to an `Observable`
- The `ViewController` converts the `ViewModel` `Observable`s to `Publisher`s and sinks on them (as a demonstration of bridging from `Observable` to `Publisher`; not by design!)